### PR TITLE
Fix operators imports

### DIFF
--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -55,16 +55,16 @@ import Data.Tuple (Tuple(..), fst, snd)
 import Prim.Row as Row
 import Prim.RowList (class RowToList, RowList)
 import Prim.RowList as RowList
-import PureScript.CST.Types (Declaration(..), Export, Foreign(..), Ident, Import, Labeled(..), Module, ModuleName, Name(..), Operator(..), Proper, QualifiedName(..))
+import PureScript.CST.Types (Declaration(..), Export, Foreign(..), Ident, Import, Labeled(..), Module, ModuleName, Name(..), Operator, Proper, QualifiedName(..))
 import Record as Record
 import Record.Builder (Builder)
 import Record.Builder as Builder
 import Safe.Coerce (coerce)
 import Tidy.Codegen (module_)
 import Tidy.Codegen as Codegen
-import Tidy.Codegen.Class (class ToModuleName, class ToName, class ToToken, toModuleName, toToken)
+import Tidy.Codegen.Class (class ToModuleName, class ToName, class ToToken, toModuleName, toQualifiedName, toToken)
 import Tidy.Codegen.Common (toSourceToken)
-import Tidy.Codegen.Types (Qualified(..), SymbolName(..))
+import Tidy.Codegen.Types (Qualified(..), SymbolName)
 import Type.Proxy (Proxy(..))
 
 data CodegenExport
@@ -271,11 +271,11 @@ importValue = withQualifiedName (ImportName <<< CodegenImportValue)
 
 -- | Imports a value operator, yield. Use with `importFrom`.
 importOp :: forall name. ToToken name (Qualified SymbolName) => name -> ImportName Operator
-importOp = withQualifiedName \a b -> ImportName (CodegenImportOp a) (coerce b)
+importOp = withQualifiedName \a b -> ImportName (CodegenImportOp a) (toQualifiedName b)
 
 -- | Imports a type operator. Use with `importFrom`.
 importTypeOp :: forall name. ToToken name (Qualified SymbolName) => name -> ImportName Operator
-importTypeOp = withQualifiedName \a b -> ImportName (CodegenImportTypeOp a) (coerce b)
+importTypeOp = withQualifiedName \a b -> ImportName (CodegenImportTypeOp a) (toQualifiedName b)
 
 -- | Imports a class. Use with `importFrom`.
 importClass :: forall name. ToToken name (Qualified Proper) => name -> ImportName Proper

--- a/test/snapshots/CodegenMonad.output
+++ b/test/snapshots/CodegenMonad.output
@@ -1,10 +1,14 @@
-module Test.Monad (getNum) where
+module Test.Monad (alt', alt'', getNum) where
 
 import Prelude
 
+import Control.Alt ((<|>))
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
 
 getNum :: String -> Map String Int -> Maybe Int
 getNum key = maybe (Just 0) <<< Map.lookup key
+
+alt' a b = a <|> b
+alt'' a b = (<|>) a b

--- a/test/snapshots/CodegenMonad.purs
+++ b/test/snapshots/CodegenMonad.purs
@@ -6,8 +6,8 @@ import Effect (Effect)
 import Partial.Unsafe (unsafePartial)
 import PureScript.CST.Types (Module)
 import Test.Util (log)
-import Tidy.Codegen (binaryOp, binderVar, declSignature, declValue, exprApp, exprCtor, exprIdent, exprInt, exprOp, printModule, typeApp, typeArrow, typeCtor)
-import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOpen, importType, importValue, write)
+import Tidy.Codegen (binaryOp, binderVar, declSignature, declValue, exprApp, exprCtor, exprIdent, exprInt, exprOp, exprOpName, printModule, typeApp, typeArrow, typeCtor)
+import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOp, importOpen, importType, importTypeOp, importValue, write)
 
 test :: Module Void
 test = unsafePartial do
@@ -18,6 +18,7 @@ test = unsafePartial do
     maybeFn <- importFrom "Data.Maybe" (importValue "maybe")
     mapTy <- importFrom "Data.Map" (importType "Map")
     mapLookup <- importFrom "Data.Map" (importValue "Map.lookup")
+    altOp <- importFrom "Control.Alt" (importOp "<|>")
     exporting do
       write $ declSignature "getNum" do
         typeArrow
@@ -38,6 +39,16 @@ test = unsafePartial do
               ( exprApp (exprIdent mapLookup)
                   [ exprIdent "key" ]
               )
+          ]
+      write $ declValue "alt'" [ binderVar "a", binderVar "b" ] do
+        exprOp (exprIdent "a")
+          [ binaryOp altOp
+              (exprIdent "b")
+          ]
+      write $ declValue "alt''" [ binderVar "a", binderVar "b" ] do
+        exprApp (exprOpName altOp)
+          [ exprIdent "a"
+          , exprIdent "b"
           ]
 
 main :: Effect Unit


### PR DESCRIPTION
Fixes #5. This also lets you import operators without the wrapping parens in the string.

cc @blinky3713