### PR TITLE
Enable open imports with hidden members

### DIFF
--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -287,8 +287,8 @@ importOpenHiding
   => ToImportFrom name imp
   => mod
   -> name
-  -> CodegenT e m imp
-importOpenHiding mod = toImportFrom \(ImportName imp qn@(QualifiedName { module: mbMod })) ->
+  -> CodegenT e m Unit
+importOpenHiding mod = void <<< toImportFrom \(ImportName imp qn@(QualifiedName { module: mbMod })) ->
   CodegenT $ state \st -> do
     Tuple qn $ case mbMod of
       Nothing -> st

--- a/test/snapshots/CodegenImports.output
+++ b/test/snapshots/CodegenImports.output
@@ -7,3 +7,5 @@ import Data.Maybe as Maybe
 import Data.Foldable (class Foldable)
 import Data.Either (Either(Left, Right))
 import Type.Row (type (+))
+import Prim hiding (Type)
+import Prim hiding (Row) as P

--- a/test/snapshots/CodegenImports.purs
+++ b/test/snapshots/CodegenImports.purs
@@ -6,7 +6,7 @@ import Effect (Effect)
 import Partial.Unsafe (unsafePartial)
 import PureScript.CST.Types (Module)
 import Test.Util (log)
-import Tidy.Codegen (declImport, declImportAs, importClass, importOp, importTypeAll, importTypeMembers, importTypeOp, importValue, module_, printModule)
+import Tidy.Codegen (declImport, declImportAs, declImportHiding, declImportHidingAs, importClass, importOp, importType, importTypeAll, importTypeMembers, importTypeOp, importValue, module_, printModule)
 
 test :: Module Void
 test = unsafePartial do
@@ -23,6 +23,8 @@ test = unsafePartial do
     , declImport "Type.Row"
         [ importTypeOp "+"
         ]
+    , declImportHiding "Prim" [ importType "Type" ]
+    , declImportHidingAs "Prim" [ importType "Row" ] "P"
     ]
     []
 


### PR DESCRIPTION
Fixes #9 by following the same code used for `importFrom`.

I haven't yet tested this locally to verify that it works. 