### PR TITLE
Refactor unqualified imports to deduplicate closed then open imported modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           purescript: "0.14.4"
           psa: "0.8.2"
-          spago: "0.20.3"
+          spago: "latest"
           purs-tidy: "latest"
       - uses: actions/cache@v2
         # This cache uses the .dhall files to know when it should reinstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           purescript: "0.14.4"
           psa: "0.8.2"
-          spago: "latest"
+          spago: "0.20.3"
           purs-tidy: "latest"
       - uses: actions/cache@v2
         # This cache uses the .dhall files to know when it should reinstall

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -6,12 +6,12 @@ module Tidy.Codegen.Monad
   , CodegenExport(..)
   , CodegenImport(..)
   , ImportName(..)
-  , ImportFromValue(..)
-  , ImportFromType(..)
-  , ImportFromTypeOp(..)
-  , ImportFromOp(..)
-  , ImportFromClass(..)
-  , ImportFromCtor(..)
+  , ImportFromValue
+  , ImportFromType
+  , ImportFromTypeOp
+  , ImportFromOp
+  , ImportFromClass
+  , ImportFromCtor
   , write
   , writeAndExport
   , exportValue

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -320,7 +320,7 @@ importOpen mod = CodegenT $ modify_ \st ->
         st.importsUnqualified
     }
 
--- | Imports a module with as an open import with imported members hidden.
+-- | Imports a module as an open import with imported members hidden.
 -- |
 -- | ```purescript
 -- | example = do

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -130,7 +130,7 @@ type CodegenState e =
   -- | import forms on the left will be overridden by import forms on the right
   -- | ```
   -- | let map1 = Map.singleton
-  -- | (map1 "foo" (map1 "bar" $ Just _)) < (map1 "foo" (map1 "bar" Nothing))
+  -- | (map1 "foo" (map1 "bar" $ Set.singleton "baz")) < (map1 "foo" (map1 "bar" Set.empty))
   -- | ```
   , importsQualified :: Map ModuleName (Map ModuleName (Set CodegenImport))
   , declarations :: List (Declaration e)

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -70,7 +70,7 @@ import Prim as Prim
 import Prim.Row as Row
 import Prim.RowList (class RowToList, RowList)
 import Prim.RowList as RowList
-import PureScript.CST.Types (Declaration(..), Export, Expr, Foreign(..), Ident, Import, Labeled(..), Module, ModuleName, Name(..), Proper, QualifiedName(..), Type)
+import PureScript.CST.Types (Declaration(..), Export, Expr, Foreign(..), Ident, Import, Labeled(..), Module, ModuleName, Name(..), Operator, Proper, QualifiedName(..), Type)
 import Record as Record
 import Record.Builder (Builder)
 import Record.Builder as Builder
@@ -487,9 +487,9 @@ codegenImportToCST = case _ of
 
 newtype ImportFromType = ImportFromType (ImportName Proper)
 newtype ImportFromCtor = ImportFromCtor (ImportName Proper)
-newtype ImportFromTypeOp = ImportFromTypeOp (ImportName SymbolName)
+newtype ImportFromTypeOp = ImportFromTypeOp (ImportName Operator)
 newtype ImportFromValue = ImportFromValue (ImportName Ident)
-newtype ImportFromOp = ImportFromOp (ImportName SymbolName)
+newtype ImportFromOp = ImportFromOp (ImportName Operator)
 newtype ImportFromClass = ImportFromClass (ImportName Proper)
 
 type ImportResolver f = forall n. ImportName n -> f (QualifiedName n)

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -123,15 +123,15 @@ derive instance Ord UnqualifiedImportModule
 type CodegenState e =
   { exports :: Set CodegenExport
   , importsUnqualified :: Map ModuleName UnqualifiedImportModule
-  -- | `import Foo as Bar` = `Map.singleton "Foo" $ Map.singleton "Bar" Nothing`
-  -- | `import Foo (baz) as Bar` = `Map.singleton "Foo" $ Map.singleton "Bar" $ Just $ NES.singleton "baz"`
-  -- |
-  -- | If a module is imported multiple times qualified,
-  -- | import forms on the left will be overridden by import forms on the right
-  -- | ```
-  -- | let map1 = Map.singleton
-  -- | (map1 "foo" (map1 "bar" $ Set.singleton "baz")) < (map1 "foo" (map1 "bar" Set.empty))
-  -- | ```
+  -- If a qualified import with explicit members (e.g. `import Foo (baz) as Bar`) is imported
+  -- and then the same module is imported with the same qualifier
+  -- but without any members (e.g. `import Foo as Bar`),
+  -- then the no-member qualified import version "wins":
+  -- For example, if the module is imported twice like this:
+  --    import Foo (baz) as Bar
+  --    import Foo as Bar
+  -- then the output will only have this:
+  --    import Foo as Bar
   , importsQualified :: Map ModuleName (Map ModuleName (Set CodegenImport))
   , declarations :: List (Declaration e)
   }

--- a/src/Tidy/Codegen/Monad.purs
+++ b/src/Tidy/Codegen/Monad.purs
@@ -117,8 +117,8 @@ data UnqualifiedImportModule
   = ClosedImporting (NonEmptySet CodegenImport)
   | OpenHiding (Set CodegenImport)
 
-derive instance eqUnqualifiedImportModule :: Eq UnqualifiedImportModule
-derive instance ordUnqualifiedImportModule :: Ord UnqualifiedImportModule
+derive instance Eq UnqualifiedImportModule
+derive instance Ord UnqualifiedImportModule
 
 type CodegenState e =
   { exports :: Set CodegenExport

--- a/test/GenerateExamples.purs
+++ b/test/GenerateExamples.purs
@@ -72,23 +72,23 @@ generateExamplesModule modName src = case parseModule src of
                 pure expr
               ExampleType -> do
                 exprDeclType <- importFrom "Tidy.Codegen" (importValue "declType")
-                pure $ exprApp (exprIdent exprDeclType)
+                pure $ exprApp exprDeclType
                   [ exprString (String.toUpper (String.take 1 ident) <> String.drop 1 ident <> "Example")
                   , exprArray []
                   , expr
                   ]
               ExampleExpr -> do
                 exprDeclValue <- importFrom "Tidy.Codegen" (importValue "declValue")
-                pure $ exprApp (exprIdent exprDeclValue)
+                pure $ exprApp exprDeclValue
                   [ exprString (ident <> "Example")
                   , exprArray []
                   , expr
                   ]
 
-          write $ declSignature "test" (typeApp (typeCtor typeModule) [ typeCtor "Void" ])
+          write $ declSignature "test" (typeApp typeModule [ typeCtor "Void" ])
           write $ declValue "test" [] do
-            exprApp (exprIdent exprUnsafePartial)
-              [ exprApp (exprIdent exprModule)
+            exprApp exprUnsafePartial
+              [ exprApp exprModule
                   [ exprString (unwrap modName)
                   , exprArray []
                   , exprArray []
@@ -96,10 +96,10 @@ generateExamplesModule modName src = case parseModule src of
                   ]
               ]
 
-          write $ declSignature "main" (typeApp (typeCtor typeEffect) [ typeCtor "Unit" ])
+          write $ declSignature "main" (typeApp typeEffect [ typeCtor "Unit" ])
           write $ declValue "main" [] do
-            exprApp (exprIdent exprLog)
-              [ exprApp (exprIdent exprPrintModule)
+            exprApp exprLog
+              [ exprApp exprPrintModule
                   [ exprIdent "test"
                   ]
               ]

--- a/test/snapshots/CodegenMonad.output
+++ b/test/snapshots/CodegenMonad.output
@@ -1,11 +1,15 @@
 module Test.Monad (alt', alt'', getNum) where
 
 import Prelude
+import Prim hiding (Type)
+import Prim.Boolean
 
 import Control.Alt ((<|>))
+import Data.Either as Either
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Maybe (Maybe(..), maybe)
+import Data.Set (Set, isEmpty) as Set
 
 getNum :: String -> Map String Int -> Maybe Int
 getNum key = maybe (Just 0) <<< Map.lookup key

--- a/test/snapshots/CodegenMonad.purs
+++ b/test/snapshots/CodegenMonad.purs
@@ -6,8 +6,8 @@ import Effect (Effect)
 import Partial.Unsafe (unsafePartial)
 import PureScript.CST.Types (Module)
 import Test.Util (log)
-import Tidy.Codegen (binaryOp, binderVar, declSignature, declValue, exprApp, exprCtor, exprIdent, exprInt, exprOp, exprOpName, printModule, typeApp, typeArrow, typeCtor)
-import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOp, importOpen, importType, importTypeOp, importValue, write)
+import Tidy.Codegen (binaryOp, binderVar, declSignature, declValue, exprApp, exprIdent, exprInt, exprOp, printModule, typeApp, typeArrow, typeCtor)
+import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOp, importOpen, importType, importValue, write)
 
 test :: Module Void
 test = unsafePartial do
@@ -23,30 +23,30 @@ test = unsafePartial do
       write $ declSignature "getNum" do
         typeArrow
           [ typeCtor "String"
-          , typeApp (typeCtor mapTy) [ typeCtor "String", typeCtor "Int" ]
+          , typeApp mapTy [ typeCtor "String", typeCtor "Int" ]
           ]
-          ( typeApp (typeCtor maybeTy)
+          ( typeApp maybeTy
               [ typeCtor "Int" ]
           )
       write $ declValue "getNum" [ binderVar "key" ] do
         exprOp
-          ( exprApp (exprIdent maybeFn)
-              [ exprApp (exprCtor justCtor)
+          ( exprApp maybeFn
+              [ exprApp justCtor
                   [ exprInt 0 ]
               ]
           )
           [ binaryOp "<<<"
-              ( exprApp (exprIdent mapLookup)
+              ( exprApp mapLookup
                   [ exprIdent "key" ]
               )
           ]
       write $ declValue "alt'" [ binderVar "a", binderVar "b" ] do
         exprOp (exprIdent "a")
-          [ binaryOp altOp
+          [ altOp.binaryOp
               (exprIdent "b")
           ]
       write $ declValue "alt''" [ binderVar "a", binderVar "b" ] do
-        exprApp (exprOpName altOp)
+        exprApp altOp.exprOpName
           [ exprIdent "a"
           , exprIdent "b"
           ]


### PR DESCRIPTION
Fixes #16, fixes #9, and fixes #18.

Regarding #16, given the following three unqualified imports:
```
import Foo (bar)
import Foo
import Foo hiding (baz)
```
this PR outputs `import Foo hiding (baz)`. The `hiding` keyword is not frequently used, so when it is used, I believe it should take precedent over previous import statements. Thus the hiding open import "wins" against the other two. When a closed import is followed by a regular open import, the regular open import "wins".

Similarly, this PR adds support for the ability to write `import Foo (bar) as Baz`, which restricts that to which the `Baz` alias specifically refers. This is exposed via the `importFromAlias` function.

Regarding #9, I added an `importOpenHiding` function.

Regarding #18, values are automatically boxed.