### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: purescript-contrib/setup-purescript@main
         with:
-          purescript: "0.14.4"
+          purescript: "0.15.0"
           psa: "0.8.2"
-          spago: "latest"
-          purs-tidy: "latest"
+          spago: "0.20.9"
+          purs-tidy: "0.8.0"
       - uses: actions/cache@v2
         # This cache uses the .dhall files to know when it should reinstall
         # and rebuild packages. It caches both the installed packages from

--- a/packages.dhall
+++ b/packages.dhall
@@ -18,7 +18,7 @@ let additions =
           , "tuples"
           ]
         , repo = "https://github.com/natefaubion/purescript-tidy.git"
-        , version = "trh/purs-0.15"
+        , version = "v0.9.0"
         }
       }
 

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,35 +1,9 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210811/packages.dhall sha256:a2de7ef2f2e753733eddfa90573a82da0c7c61d46fa87d015b7f15ef8a6e97d5
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220513/packages.dhall
+        sha256:1ed784f37ae6131d99acd542d058d5ce39954ccaacc3adba5cc7cf1549d2bffa
 
 let additions =
-      { dodo-printer =
-        { dependencies =
-          [ "ansi", "foldable-traversable", "lists", "maybe", "strings" ]
-        , repo = "https://github.com/natefaubion/purescript-dodo-printer.git"
-        , version = "v2.1.0"
-        }
-      , language-cst-parser =
-        { dependencies =
-          [ "arrays"
-          , "const"
-          , "effect"
-          , "either"
-          , "foldable-traversable"
-          , "free"
-          , "functors"
-          , "maybe"
-          , "numbers"
-          , "ordered-collections"
-          , "strings"
-          , "transformers"
-          , "tuples"
-          , "typelevel-prelude"
-          ]
-        , repo =
-            "https://github.com/natefaubion/purescript-language-cst-parser.git"
-        , version = "v0.9.1"
-        }
-      , tidy =
+      { tidy =
         { dependencies =
           [ "arrays"
           , "dodo-printer"
@@ -43,9 +17,8 @@ let additions =
           , "strings"
           , "tuples"
           ]
-        , repo =
-            "https://github.com/natefaubion/purescript-tidy.git"
-        , version = "v0.7.0"
+        , repo = "https://github.com/natefaubion/purescript-tidy.git"
+        , version = "trh/purs-0.15"
         }
       }
 

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,15 +1,3 @@
-{-
-Welcome to a Spago project!
-You can edit this file as you like.
-
-Need help? See the following resources:
-- Spago documentation: https://github.com/purescript/spago
-- Dhall language tour: https://docs.dhall-lang.org/tutorials/Language-Tour.html
-
-When creating a new Spago project, you can use
-`spago init --no-comments` or `spago init -C`
-to generate this file without the comments in this block.
--}
 { name = "tidy-codegen"
 , dependencies =
   [ "aff"

--- a/src/Tidy/Codegen.purs
+++ b/src/Tidy/Codegen.purs
@@ -122,6 +122,7 @@ module Tidy.Codegen
   , typeRow
   , typeRowEmpty
   , typeString
+  , typeInt
   , typeVar
   , typeVarKinded
   , typeWildcard
@@ -327,6 +328,17 @@ typeRecordEmpty = typeRecord ([] :: Array (Tuple Label _)) Nothing
 -- | ```
 typeString :: forall e. String -> CST.Type e
 typeString str = TypeString (toSourceToken (TokString (unwrap (escapeSourceString str)) str)) str
+
+-- | Constructs a type-level int
+-- |
+-- | ```
+-- | exampleType = typeInt (-1)
+-- | ```
+typeInt :: forall e. Int -> CST.Type e
+typeInt n = TypeInt neg (toSourceToken (TokInt (show val) (SmallInt val))) (SmallInt val)
+  where
+  val = abs n
+  neg = if n < 0 then Just tokNegate else Nothing
 
 -- | Constructs a type with a kind annotation.
 -- |

--- a/src/Tidy/Codegen/Class.purs
+++ b/src/Tidy/Codegen/Class.purs
@@ -541,6 +541,8 @@ instance OverLeadingComments e => OverLeadingComments (CST.Type e) where
     TypeWildcard a -> TypeWildcard (overLeadingComments k a)
     TypeHole a -> TypeHole (overLeadingComments k a)
     TypeString a b -> TypeString (overLeadingComments k a) b
+    TypeInt (Just a) b c -> TypeInt (Just (overLeadingComments k a)) b c
+    TypeInt _ b c -> TypeInt Nothing (overLeadingComments k b) c
     TypeRow a -> TypeRow (overLeadingComments k a)
     TypeRecord a -> TypeRecord (overLeadingComments k a)
     TypeForall a b c d -> TypeForall (overLeadingComments k a) b c d
@@ -552,7 +554,6 @@ instance OverLeadingComments e => OverLeadingComments (CST.Type e) where
     TypeArrowName a -> TypeArrowName (overLeadingComments k a)
     TypeConstrained a b c -> TypeConstrained (overLeadingComments k a) b c
     TypeParens a -> TypeParens (overLeadingComments k a)
-    TypeUnaryRow a b -> TypeUnaryRow (overLeadingComments k a) b
     TypeError e -> TypeError (overLeadingComments k e)
 
 instance OverLeadingComments e => OverLeadingComments (Expr e) where

--- a/test/Snapshot.purs
+++ b/test/Snapshot.purs
@@ -72,7 +72,7 @@ snapshotMainOutput directory accept mbPattern = do
 
   runSnapshot :: String -> Aff SnapshotTest
   runSnapshot name = flip catchError (makeErrorResult name) do
-    result <- exec $ "node -e 'require(\"./output/" <> name <> "/index.js\").main()'"
+    result <- exec $ "node --input-type=module -e 'import { main } from \"./output/" <> name <> "/index.js\";main()'"
     case result of
       { error: Just err } ->
         throwError err

--- a/test/Snapshot.purs
+++ b/test/Snapshot.purs
@@ -2,7 +2,7 @@ module Test.Snapshot where
 
 import Prelude
 
-import Control.MonadZero (guard)
+import Control.Alternative (guard)
 import Control.Parallel (parTraverse)
 import Data.Array (mapMaybe)
 import Data.Array as Array

--- a/test/snapshots/CodegenMonad.purs
+++ b/test/snapshots/CodegenMonad.purs
@@ -7,7 +7,7 @@ import Partial.Unsafe (unsafePartial)
 import PureScript.CST.Types (Module)
 import Test.Util (log)
 import Tidy.Codegen (binaryOp, binderVar, declSignature, declValue, exprApp, exprCtor, exprIdent, exprInt, exprOp, exprOpName, printModule, typeApp, typeArrow, typeCtor)
-import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOp, importOpen, importType, importTypeOp, importValue, write)
+import Tidy.Codegen.Monad (codegenModule, exporting, importCtor, importFrom, importOp, importOpen, importType, importValue, write)
 
 test :: Module Void
 test = unsafePartial do


### PR DESCRIPTION
This upgrades the library for PureScript 0.15-related changes made in dependencies. Should not be merged until https://github.com/natefaubion/purescript-tidy/pull/96 is merged.